### PR TITLE
Eclipse git ignore file

### DIFF
--- a/AIO/.gitignore
+++ b/AIO/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+/.settings/
+.classpath
+.project


### PR DESCRIPTION
Added `.gitignore` to ignore Eclipse hidden files, like settings, bin and classpath.

Will make it easier to do `git add .` to add all changes at ones.