### PR TITLE
Fixed case sensitive path for Linux

### DIFF
--- a/AIO/src/org/aio/activities/grand_exchange/GrandExchangeHelper.java
+++ b/AIO/src/org/aio/activities/grand_exchange/GrandExchangeHelper.java
@@ -32,7 +32,7 @@ public class GrandExchangeHelper extends MethodProvider {
     public static Map<String, Integer> getAllGEItems() {
         if (allGEItems.isEmpty()) {
 
-            File summaryFile = Paths.get(System.getProperty("user.home"), "Osbot", "Data", "explv_aio_rsbuddy_summary.json").toFile();
+            File summaryFile = Paths.get(System.getProperty("user.home"), "OSBot", "Data", "explv_aio_rsbuddy_summary.json").toFile();
 
             try {
                 if (!summaryFile.exists()) {

--- a/AIO/src/org/aio/activities/grand_exchange/GrandExchangeHelper.java
+++ b/AIO/src/org/aio/activities/grand_exchange/GrandExchangeHelper.java
@@ -32,7 +32,7 @@ public class GrandExchangeHelper extends MethodProvider {
     public static Map<String, Integer> getAllGEItems() {
         if (allGEItems.isEmpty()) {
 
-            File summaryFile = Paths.get(System.getProperty("user.home"), "osbot", "data", "explv_aio_rsbuddy_summary.json").toFile();
+            File summaryFile = Paths.get(System.getProperty("user.home"), "Osbot", "Data", "explv_aio_rsbuddy_summary.json").toFile();
 
             try {
                 if (!summaryFile.exists()) {


### PR DESCRIPTION
Fixed case sensitive path for Linux
The path that was checked if existed was all with lower cases, which was not matching the path OSBot uses.