### PR TITLE
Update Romeo&Juliet - Fix stuck at Cadava bush

### DIFF
--- a/AIO/src/org/aio/activities/quests/RomeoAndJuliet.java
+++ b/AIO/src/org/aio/activities/quests/RomeoAndJuliet.java
@@ -154,6 +154,9 @@ public class RomeoAndJuliet extends QuestActivity {
     private void getItemFromRandomObject(Area place, String itemName, String objectName, String interaction) throws InterruptedException {
         if (place.contains(myPlayer())) {
             List<RS2Object> objects = getObjects().filter(o -> o.getName().equals(objectName) && o.hasAction(interaction));
+            if(objects.isEmpty()){
+                return;
+            }
             RS2Object object = objects.get(random(0,objects.size()-1));
             if (object != null && object.interact(interaction)) {
                 Sleep.sleepUntil(() -> getInventory().contains(itemName), 15000);

--- a/AIO/src/org/aio/activities/quests/RomeoAndJuliet.java
+++ b/AIO/src/org/aio/activities/quests/RomeoAndJuliet.java
@@ -8,6 +8,7 @@ import org.osbot.rs07.api.map.Position;
 import org.osbot.rs07.api.model.NPC;
 import org.osbot.rs07.api.model.RS2Object;
 import org.osbot.rs07.api.ui.Tab;
+import java.util.List;
 
 public class RomeoAndJuliet extends QuestActivity {
 
@@ -109,7 +110,7 @@ public class RomeoAndJuliet extends QuestActivity {
         } else if (getInventory().contains("Cadava berries")) {
             talkToApothecary();
         } else {
-            getItemFromObject(BERRIES, "Cadava berries", "Cadava bush", "Pick-from");
+            getItemFromRandomObject(BERRIES, "Cadava berries", "Cadava bush", "Pick-from");
         }
     }
 
@@ -150,9 +151,10 @@ public class RomeoAndJuliet extends QuestActivity {
         }
     }
 
-    private void getItemFromObject(Area place, String itemName, String objectName, String interaction) throws InterruptedException {
+    private void getItemFromRandomObject(Area place, String itemName, String objectName, String interaction) throws InterruptedException {
         if (place.contains(myPlayer())) {
-            RS2Object object = getObjects().closest(o -> o.getName().equals(objectName) && o.hasAction(interaction));
+            List<RS2Object> objects = getObjects().filter(o -> o.getName().equals(objectName) && o.hasAction(interaction));
+            RS2Object object = objects.get(random(0,objects.size()-1));
             if (object != null && object.interact(interaction)) {
                 Sleep.sleepUntil(() -> getInventory().contains(itemName), 15000);
             }


### PR DESCRIPTION
At first I added this as a Antipattern mechanic, as you know, as it turns out you can get stuck at a bush for an extended periode of time when an other bot, lets be real in f2p are only bots, picks a berry from the same bush.

The cooldown is pretty long so it could be a nice addition.