### PR TITLE
Refactoring quest stuff

### DIFF
--- a/AIO/src/org/aio/activities/quests/CooksAssistant.java
+++ b/AIO/src/org/aio/activities/quests/CooksAssistant.java
@@ -65,6 +65,42 @@ public class CooksAssistant extends QuestActivity {
             "Actually, I know where to find this stuff."
     );
 
+    private final ItemCompleter potItemCompleter = new ItemCompleter(
+            "Pot",
+            COOK_ROOM
+    );
+
+    private final ItemCompleter bucketItemCompleter = new ItemCompleter(
+            "Bucket",
+            BASEMENT
+    );
+
+    private final ItemCompleter milkItemCompleter = new ItemCompleter(
+            "Dairy COW",
+            "Bucket of milk",
+            "Milk",
+            COW
+    );
+
+    private final ItemCompleter eggItemCompleter = new ItemCompleter(
+            "Egg",
+            CHICKEN
+    );
+
+    private final ItemCompleter wheatItemCompleter = new ItemCompleter(
+            "Wheat",
+            "Grain",
+            "Pick",
+            WHEAT
+    );
+
+    private final ItemCompleter flourItemCompleter = new ItemCompleter(
+            "Flour BIN",
+            "Pot of flour",
+            "Empty",
+            BIN
+    );
+
     public CooksAssistant() {
         super(Quest.COOKS_ASSISTANT);
     }
@@ -73,6 +109,12 @@ public class CooksAssistant extends QuestActivity {
     public void onStart() {
         depositAllBanking.exchangeContext(getBot());
         cookDialogueCompleter.exchangeContext(getBot());
+        potItemCompleter.exchangeContext(getBot());
+        bucketItemCompleter.exchangeContext(getBot());
+        milkItemCompleter.exchangeContext(getBot());
+        eggItemCompleter.exchangeContext(getBot());
+        wheatItemCompleter.exchangeContext(getBot());
+        flourItemCompleter.exchangeContext(getBot());
         getBot().addMessageListener(MILL_MESSAGE_LISTENER);
     }
 
@@ -117,18 +159,18 @@ public class CooksAssistant extends QuestActivity {
 
     private void getItemsNeeded() throws InterruptedException {
         if (!getInventory().contains("Pot", "Pot of flour", "Bucket of milk")) {
-            getGroundItem(COOK_ROOM, "Pot");
+            potItemCompleter.run();
         } else if (!getInventory().contains("Bucket", "Bucket of milk")) {
-            getGroundItem(BASEMENT, "Bucket");
+            bucketItemCompleter.run();
         } else if (getInventory().contains("Bucket") && !getInventory().contains("Bucket of milk")) {
-            getItemFromObject(COW, "Bucket of milk", "Dairy COW", "Milk");
+            milkItemCompleter.run();
         } else if (!getInventory().contains("Egg")) {
-            getGroundItem(CHICKEN, "Egg");
+            eggItemCompleter.run();
         } else if (!getInventory().contains("Pot of flour")) {
 
             // Get grain
             if (!put && !getInventory().contains("Grain")) {
-                getItemFromObject(WHEAT, "Grain", "Wheat", "Pick");
+                wheatItemCompleter.run();
             }
 
             // Put grain
@@ -143,7 +185,7 @@ public class CooksAssistant extends QuestActivity {
 
             // Get flour
             if (operated && put) {
-                getItemFromObject(BIN, "Pot of flour", "Flour BIN", "Empty");
+                flourItemCompleter.run();
             }
         }
     }
@@ -183,28 +225,6 @@ public class CooksAssistant extends QuestActivity {
             if (controls.interact("Operate")) {
                 Sleep.sleepUntil(() -> operated, 10000);
             }
-        }
-    }
-
-    private void getItemFromObject(Area place, String itemName, String objectName, String interaction) throws InterruptedException {
-        if (place.contains(myPlayer())) {
-            RS2Object object = getObjects().closest(objectName);
-            if (object != null && object.interact(interaction)) {
-                Sleep.sleepUntil(() -> getInventory().contains(itemName) && !myPlayer().isAnimating(), 15000);
-            }
-        } else {
-            getWalking().webWalk(place);
-        }
-    }
-
-    private void getGroundItem(Area place, String itemName) throws InterruptedException {
-        if (place.contains(myPosition())) {
-            GroundItem itemToGet = getGroundItems().closest(itemName);
-            if (itemToGet != null && itemToGet.interact("Take")) {
-                Sleep.sleepUntil(() -> getInventory().contains(itemName), 8000);
-            }
-        } else {
-            getWalking().webWalk(place);
         }
     }
 

--- a/AIO/src/org/aio/activities/quests/CooksAssistant.java
+++ b/AIO/src/org/aio/activities/quests/CooksAssistant.java
@@ -76,7 +76,7 @@ public class CooksAssistant extends QuestActivity {
     );
 
     private final ItemCompleter milkItemCompleter = new ItemCompleter(
-            "Dairy COW",
+            "Dairy cow",
             "Bucket of milk",
             "Milk",
             COW
@@ -95,7 +95,7 @@ public class CooksAssistant extends QuestActivity {
     );
 
     private final ItemCompleter flourItemCompleter = new ItemCompleter(
-            "Flour BIN",
+            "Flour bin",
             "Pot of flour",
             "Empty",
             BIN

--- a/AIO/src/org/aio/activities/quests/DialogueCompleter.java
+++ b/AIO/src/org/aio/activities/quests/DialogueCompleter.java
@@ -41,13 +41,26 @@ public class DialogueCompleter extends Executable {
         if (npc == null) {
             if (area != null && !area.contains(myPosition())) {
                 if(path != null && usePreferredWalkType == WalkType.PATH){
+                    log(String.format("[Dialog] Using Path moving towards %s Pos[%s,%s,%s]",
+                            npcName,
+                            path.get(path.size()-1).getX(),
+                            path.get(path.size()-1).getY(),
+                            path.get(path.size()-1).getZ()
+                    ));
                     getWalking().walkPath(path);
                 }else{
+                    Position rnd = area.getRandomPosition();
+                    log(String.format("[Dialog] Using Webwalk moving towards %s Pos[%s,%s,%s]",
+                            npcName,
+                            rnd.getX(),
+                            rnd.getY(),
+                            rnd.getZ()
+                    ));
                     getWalking().webWalk(area);
                 }
                 return;
             } else {
-                log(String.format("Could not find NPC with name '%s'", npcName));
+                log(String.format("[Dialog] Could not find NPC with name '%s'", npcName));
                 setFailed();
                 return;
             }

--- a/AIO/src/org/aio/activities/quests/DialogueCompleter.java
+++ b/AIO/src/org/aio/activities/quests/DialogueCompleter.java
@@ -2,7 +2,6 @@ package org.aio.activities.quests;
 
 import org.aio.util.Executable;
 import org.aio.util.Sleep;
-import org.osbot.rs07.api.Walking;
 import org.osbot.rs07.api.map.Area;
 import org.osbot.rs07.api.map.Position;
 import org.osbot.rs07.api.model.NPC;

--- a/AIO/src/org/aio/activities/quests/DialogueCompleter.java
+++ b/AIO/src/org/aio/activities/quests/DialogueCompleter.java
@@ -2,33 +2,50 @@ package org.aio.activities.quests;
 
 import org.aio.util.Executable;
 import org.aio.util.Sleep;
+import org.osbot.rs07.api.Walking;
 import org.osbot.rs07.api.map.Area;
+import org.osbot.rs07.api.map.Position;
 import org.osbot.rs07.api.model.NPC;
+
+import java.util.List;
 
 public class DialogueCompleter extends Executable {
 
     private final String npcName;
     private final String[] dialogueOptions;
     private Area area;
-
-    public DialogueCompleter(final String npcName, final Area area, final String... dialogueOptions) {
-        this.npcName = npcName;
-        this.area = area;
-        this.dialogueOptions = dialogueOptions;
-    }
+    private List<Position> path;
 
     public DialogueCompleter(final String npcName, final String... dialogueOptions) {
         this.npcName = npcName;
         this.dialogueOptions = dialogueOptions;
     }
 
+    public DialogueCompleter(final String npcName, final Area area, final String... dialogueOptions) {
+        this(npcName, dialogueOptions);
+        this.area = area;
+    }
+
+    public DialogueCompleter(final String npcName, final Area area, final List<Position> path, final String... dialogueOptions) {
+        this(npcName, area, dialogueOptions);
+        this.path = path;
+    }
+
     @Override
     public void run() throws InterruptedException {
+        run(WalkType.PATH);
+    }
+
+    public void run(WalkType usePreferredWalkType) throws InterruptedException{
         NPC npc = getNpcs().closest(npcName);
 
         if (npc == null) {
             if (area != null && !area.contains(myPosition())) {
-                getWalking().webWalk(area);
+                if(path != null && usePreferredWalkType == WalkType.PATH){
+                    getWalking().walkPath(path);
+                }else{
+                    getWalking().webWalk(area);
+                }
                 return;
             } else {
                 log(String.format("Could not find NPC with name '%s'", npcName));
@@ -44,5 +61,10 @@ public class DialogueCompleter extends Executable {
         } else {
             getDialogues().completeDialogue(dialogueOptions);
         }
+    }
+
+    enum WalkType {
+        PATH,
+        WEBWALK
     }
 }

--- a/AIO/src/org/aio/activities/quests/ItemCompleter.java
+++ b/AIO/src/org/aio/activities/quests/ItemCompleter.java
@@ -1,0 +1,144 @@
+package org.aio.activities.quests;
+
+import org.aio.util.Executable;
+import org.aio.util.Sleep;
+import org.osbot.rs07.api.map.Area;
+import org.osbot.rs07.api.map.Position;
+import org.osbot.rs07.api.model.GroundItem;
+import org.osbot.rs07.api.model.NPC;
+import org.osbot.rs07.api.model.RS2Object;
+
+import java.util.List;
+
+public class ItemCompleter extends Executable {
+
+    private final String itemName;
+    private String objectName;
+    private final String interaction;
+    private Area area;
+    private List<Position> path;
+    private ObjectSelector objectSelector;
+
+    /*
+        Item from Ground Constructor
+     */
+    public ItemCompleter(final String itemName){
+        this.itemName = itemName;
+        this.interaction = "Take";
+        this.objectSelector = ObjectSelector.CLOSEST;
+    }
+
+    public ItemCompleter(final String itemName, final Area area){
+        this(itemName);
+        this.area = area;
+    }
+
+    public ItemCompleter(final String itemName, final Area area, List<Position> path){
+        this(itemName, area);
+        this.path = path;
+    }
+
+    /*
+        Item from Object Constructor
+     */
+    public ItemCompleter(final String objectName, final String itemName, final String interaction){
+        this.itemName = itemName;
+        this.objectName = objectName;
+        this.interaction = interaction;
+        this.objectSelector = ObjectSelector.CLOSEST;
+    }
+
+    public ItemCompleter(final String objectName, final String itemName, final String interaction, final ObjectSelector objectSelector){
+        this(objectName, itemName, interaction);
+        this.objectSelector = objectSelector;
+    }
+
+    public ItemCompleter(final String objectName, final String itemName, final String interaction, final Area area){
+        this(objectName, itemName, interaction);
+        this.area = area;
+    }
+
+    public ItemCompleter(final String objectName, final String itemName, final String interaction, final Area area, final ObjectSelector objectSelector){
+        this(objectName, itemName, interaction, objectSelector);
+        this.area = area;
+    }
+
+    public ItemCompleter(final String objectName, final String itemName, final String interaction, final Area area, final List<Position> path){
+        this(objectName, itemName, interaction, area);
+        this.path = path;
+    }
+
+    public ItemCompleter(final String objectName, final String itemName, final String interaction, final Area area, final List<Position> path, final ObjectSelector objectSelector){
+        this(objectName, itemName, interaction, area, objectSelector);
+        this.path = path;
+    }
+    /*
+        Constructor end, yikes
+     */
+
+    @Override
+    public void run() throws InterruptedException {
+        run(WalkType.PATH);
+    }
+
+    public void run(WalkType useForcedWalkType) throws InterruptedException {
+        if(objectName != null){
+            takeItemFromObject(useForcedWalkType);
+        }else{
+            takeItemFromGround(useForcedWalkType);
+        }
+    }
+
+    private void takeItemFromObject(WalkType useForcedWalkType){
+        RS2Object object = getObjects().closest(o -> o.getName().equals(objectName) && o.hasAction(interaction));
+        List<RS2Object> objects = getObjects().filter(o -> o.getName().equals(objectName) && o.hasAction(interaction));
+
+        if ((object == null && objectSelector == ObjectSelector.CLOSEST)||(objects.isEmpty() && objectSelector == ObjectSelector.RANDOM)) {
+            doWalk(useForcedWalkType);
+        }
+
+        if(objectSelector == ObjectSelector.RANDOM){
+            object = objects.get(random(objects.size()-1));
+        }
+
+        if (object.interact(interaction)) {
+            Sleep.sleepUntil(() -> getInventory().contains(itemName) && !myPlayer().isAnimating(), 15000);
+        }
+    }
+
+    private void takeItemFromGround(WalkType useForcedWalkType) {
+        GroundItem item = getGroundItems().closest(itemName);
+        if (item == null) {
+            doWalk(useForcedWalkType);
+            return;
+        }
+        if (item.interact(interaction)) {
+            Sleep.sleepUntil(() -> getInventory().contains(itemName), 8000);
+        }
+    }
+
+    private void doWalk(WalkType useForcedWalkType) {
+        if (area != null && !area.contains(myPosition())) {
+            if(path != null && useForcedWalkType == WalkType.PATH){
+                getWalking().walkPath(path);
+            }else{
+                getWalking().webWalk(area);
+            }
+            return;
+        } else {
+            log(String.format("Could not find any Objects with name '%s'", objectName));
+            setFailed();
+            return;
+        }
+    }
+
+    enum WalkType {
+        PATH,
+        WEBWALK
+    }
+
+    enum ObjectSelector{
+        CLOSEST,
+        RANDOM
+    }
+}

--- a/AIO/src/org/aio/activities/quests/ItemCompleter.java
+++ b/AIO/src/org/aio/activities/quests/ItemCompleter.java
@@ -111,6 +111,7 @@ public class ItemCompleter extends Executable {
     }
 
     private void takeItemFromObject(RS2Object object){
+        RS2Object interactObject = object;
         if(entitySelector == EntitySelector.RANDOM){
             List<RS2Object> objects = getObjects().filter(o -> o.getName().equals(entityName) && o.hasAction(interaction));
 
@@ -119,16 +120,17 @@ public class ItemCompleter extends Executable {
                 return;
             }
 
-            object = objects.get(random(objects.size()-1));
+            interactObject = objects.get(random(objects.size()-1));
         }
 
-        if (object.interact(interaction)) {
+        if (interactObject.interact(interaction)) {
             Sleep.sleepUntil(() -> !myPlayer().isMoving(), 15000 );
             Sleep.sleepUntil(() -> getInventory().contains(itemName) && !myPlayer().isAnimating(), 15000);
         }
     }
 
     private void takeItemFromNPC(NPC npc){
+        NPC interactNPC = npc;
         if(entitySelector == EntitySelector.RANDOM){
             List<NPC> npcs = getNpcs().filter(o -> o.getName().equals(entityName) && o.hasAction(interaction));
 
@@ -137,10 +139,10 @@ public class ItemCompleter extends Executable {
                 return;
             }
 
-            npc = npcs.get(random(npcs.size()-1));
+            interactNPC = npcs.get(random(npcs.size()-1));
         }
 
-        if (npc.interact(interaction)) {
+        if (interactNPC.interact(interaction)) {
             Sleep.sleepUntil(() -> !myPlayer().isMoving(), 15000 );
             Sleep.sleepUntil(() -> getInventory().contains(itemName) && !myPlayer().isAnimating(), 15000);
         }

--- a/AIO/src/org/aio/activities/quests/ItemCompleter.java
+++ b/AIO/src/org/aio/activities/quests/ItemCompleter.java
@@ -149,7 +149,7 @@ public class ItemCompleter extends Executable {
     private void takeItemFromGround(WalkType useForcedWalkType) {
         GroundItem item = getGroundItems().closest(itemName);
         log(itemName);
-        if (item == null || !item.isVisible() || !item.isOnScreen()) {
+        if (item == null || !area.contains(item)) {
             doWalk(useForcedWalkType);
             return;
         }

--- a/AIO/src/org/aio/activities/quests/ItemCompleter.java
+++ b/AIO/src/org/aio/activities/quests/ItemCompleter.java
@@ -83,11 +83,8 @@ public class ItemCompleter extends Executable {
 
     public void run(WalkType useForcedWalkType) throws InterruptedException {
         if(entityName != null){
-            log("Entity");
             takeItemFromEntity(useForcedWalkType);
         }else{
-
-            log("Ground");
             takeItemFromGround(useForcedWalkType);
         }
     }
@@ -102,10 +99,8 @@ public class ItemCompleter extends Executable {
         }
 
         if(object != null){
-            log("Object");
             takeItemFromObject(object);
         }else{
-            log("NPC");
             takeItemFromNPC(npc);
         }
     }
@@ -116,7 +111,13 @@ public class ItemCompleter extends Executable {
             List<RS2Object> objects = getObjects().filter(o -> o.getName().equals(entityName) && o.hasAction(interaction));
 
             if(objects.isEmpty()){
-                log("[ITEM-COMPLETER]Object was found but now its not in the list?");
+                log(String.format("[Item-%s] Object %s was found but now not in the List Pos[%s,%s,%s]",
+                        itemName,
+                        object.getName(),
+                        object.getX(),
+                        object.getY(),
+                        object.getZ()
+                ));
                 return;
             }
 
@@ -124,6 +125,13 @@ public class ItemCompleter extends Executable {
         }
 
         if (interactObject.interact(interaction)) {
+            log(String.format("[Item-%s] Interact with %s Pos[%s,%s,%s]",
+                    itemName,
+                    interactObject.getName(),
+                    interactObject.getX(),
+                    interactObject.getY(),
+                    interactObject.getZ()
+            ));
             Sleep.sleepUntil(() -> !myPlayer().isMoving(), 15000 );
             Sleep.sleepUntil(() -> getInventory().contains(itemName) && !myPlayer().isAnimating(), 15000);
         }
@@ -135,7 +143,13 @@ public class ItemCompleter extends Executable {
             List<NPC> npcs = getNpcs().filter(o -> o.getName().equals(entityName) && o.hasAction(interaction));
 
             if(npcs.isEmpty()){
-                log("[ITEM-COMPLETER]NPC was found but now its not in the list?");
+                log(String.format("[Item-%s] NPC %s was found but now not in the List Pos[%s,%s,%s]",
+                        itemName,
+                        interactNPC.getName(),
+                        interactNPC.getX(),
+                        interactNPC.getY(),
+                        interactNPC.getZ()
+                ));
                 return;
             }
 
@@ -143,6 +157,13 @@ public class ItemCompleter extends Executable {
         }
 
         if (interactNPC.interact(interaction)) {
+            log(String.format("[Item-%s] Interact with %s Pos[%s,%s,%s]",
+                    itemName,
+                    interactNPC.getName(),
+                    interactNPC.getX(),
+                    interactNPC.getY(),
+                    interactNPC.getZ()
+            ));
             Sleep.sleepUntil(() -> !myPlayer().isMoving(), 15000 );
             Sleep.sleepUntil(() -> getInventory().contains(itemName) && !myPlayer().isAnimating(), 15000);
         }
@@ -150,13 +171,18 @@ public class ItemCompleter extends Executable {
 
     private void takeItemFromGround(WalkType useForcedWalkType) {
         GroundItem item = getGroundItems().closest(itemName);
-        log(itemName);
         if (item == null || !area.contains(item)) {
             doWalk(useForcedWalkType);
             return;
         }
-        log("Interact");
+
         if (item.interact(interaction)) {
+            log(String.format("[Item-%s] Interact with Pos[%s,%s,%s]",
+                    itemName,
+                    item.getX(),
+                    item.getY(),
+                    item.getZ()
+            ));
             Sleep.sleepUntil(() -> getInventory().contains(itemName), 8000);
         }
     }
@@ -164,14 +190,25 @@ public class ItemCompleter extends Executable {
     private void doWalk(WalkType useForcedWalkType) {
         if (area != null && !area.contains(myPosition())) {
             if(path != null && useForcedWalkType == WalkType.PATH){
-                log("Walk Path");
+                log(String.format("[Item-%s] Using Path moving towards Pos[%s,%s,%s]",
+                        itemName,
+                        path.get(path.size()-1).getX(),
+                        path.get(path.size()-1).getY(),
+                        path.get(path.size()-1).getZ()
+                ));
                 getWalking().walkPath(path);
             }else{
-                log("Walk Area");
+                Position rnd = area.getRandomPosition();
+                log(String.format("[Item-%s] Using Webwalk moving towards Pos[%s,%s,%s]",
+                        itemName,
+                        rnd.getX(),
+                        rnd.getY(),
+                        rnd.getZ()
+                ));
                 getWalking().webWalk(area);
             }
         } else {
-            log("Failed to walk");
+            log(String.format("[Item-%s] Failed to walk", itemName));
             setFailed();
         }
     }

--- a/AIO/src/org/aio/activities/quests/RomeoAndJuliet.java
+++ b/AIO/src/org/aio/activities/quests/RomeoAndJuliet.java
@@ -2,11 +2,8 @@ package org.aio.activities.quests;
 
 import org.aio.activities.activity.Activity;
 import org.aio.activities.banking.DepositAllBanking;
-import org.aio.util.Sleep;
 import org.osbot.rs07.api.map.Area;
 import org.osbot.rs07.api.map.Position;
-import org.osbot.rs07.api.model.NPC;
-import org.osbot.rs07.api.model.RS2Object;
 import org.osbot.rs07.api.ui.Tab;
 
 import java.util.*;
@@ -62,7 +59,7 @@ public class RomeoAndJuliet extends QuestActivity {
             "Pick-from",
             BERRIES_AREA,
             BERRIES_PATH,
-            ItemCompleter.ObjectSelector.RANDOM
+            ItemCompleter.EntitySelector.RANDOM
     );
 
     private final DepositAllBanking depositAllBanking = new DepositAllBanking(QUEST_ITEMS);

--- a/AIO/src/org/aio/activities/quests/RomeoAndJuliet.java
+++ b/AIO/src/org/aio/activities/quests/RomeoAndJuliet.java
@@ -8,33 +8,62 @@ import org.osbot.rs07.api.map.Position;
 import org.osbot.rs07.api.model.NPC;
 import org.osbot.rs07.api.model.RS2Object;
 import org.osbot.rs07.api.ui.Tab;
-import java.util.List;
+
+import java.util.*;
 
 public class RomeoAndJuliet extends QuestActivity {
 
-    private static final Area ROMEO = new Area(3205, 3431, 3220, 3415);
-    private static final Area JULIET = new Area(new Position(3155, 3425, 1), new Position(3161, 3426, 1));
-    private static final Area LAWRENCE = new Area(3252, 3486, 3259, 3472);
-    private static final Area APOTHECARY = new Area(3197, 3406, 3192, 3402);
-    private static final Area BERRIES = new Area(3263, 3365, 3278, 3375);
+    private static final Area ROMEO_AREA = new Area(3205, 3431, 3220, 3415);
+    private static final Area JULIET_AREA = new Area(new Position(3155, 3425, 1), new Position(3161, 3426, 1));
+    private static final Area LAWRENCE_AREA = new Area(3252, 3486, 3259, 3472);
+    private static final Area APOTHECARY_AREA = new Area(3197, 3406, 3192, 3402);
+    private static final Area BERRIES_AREA = new Area(3263, 3365, 3278, 3375);
 
-    private static final String[] ROMEO_OPTIONS = {
+    private static final List<Position> BERRIES_PATH = Arrays.asList(new Position[]{new Position(3193,3403,0),new Position(3193,3403,0),new Position(3191,3404,0),new Position(3191,3407,0),new Position(3194,3407,0),new Position(3197,3407,0),new Position(3200,3407,0),new Position(3200,3407,0),new Position(3203,3407,0),new Position(3206,3410,0),new Position(3209,3410,0),new Position(3210,3413,0),new Position(3210,3413,0),new Position(3210,3416,0),new Position(3211,3419,0),new Position(3212,3420,0),new Position(3212,3420,0),new Position(3215,3423,0),new Position(3218,3426,0),new Position(3221,3427,0),new Position(3224,3427,0),new Position(3227,3427,0),new Position(3230,3428,0),new Position(3230,3428,0),new Position(3233,3428,0),new Position(3236,3428,0),new Position(3239,3428,0),new Position(3242,3428,0),new Position(3245,3428,0),new Position(3248,3428,0),new Position(3251,3428,0),new Position(3254,3428,0),new Position(3257,3428,0),new Position(3260,3428,0),new Position(3263,3428,0),new Position(3266,3428,0),new Position(3269,3428,0),new Position(3272,3428,0),new Position(3275,3426,0),new Position(3275,3426,0),new Position(3277,3423,0),new Position(3278,3420,0),new Position(3280,3418,0),new Position(3281,3415,0),new Position(3284,3413,0),new Position(3286,3410,0),new Position(3288,3407,0),new Position(3289,3404,0),new Position(3290,3401,0),new Position(3290,3398,0),new Position(3290,3398,0),new Position(3290,3395,0),new Position(3290,3392,0),new Position(3290,3389,0),new Position(3290,3386,0),new Position(3290,3383,0),new Position(3290,3380,0),new Position(3290,3377,0),new Position(3287,3375,0),new Position(3284,3375,0),new Position(3281,3372,0),new Position(3281,3372,0),new Position(3278,3370,0),new Position(3275,3369,0),new Position(3275,3369,0),new Position(3272,3369,0)});
+    private static final List<Position> APOTHECARY_PATH = Arrays.asList(new Position[]{new Position(3256,3371,0),new Position(3256,3371,0),new Position(3260,3371,0),new Position(3264,3371,0),new Position(3268,3371,0),new Position(3272,3374,0),new Position(3276,3375,0),new Position(3280,3375,0),new Position(3284,3375,0),new Position(3288,3375,0),new Position(3288,3375,0),new Position(3290,3379,0),new Position(3290,3383,0),new Position(3290,3387,0),new Position(3290,3391,0),new Position(3290,3395,0),new Position(3290,3399,0),new Position(3290,3403,0),new Position(3288,3407,0),new Position(3288,3407,0),new Position(3286,3411,0),new Position(3282,3414,0),new Position(3281,3418,0),new Position(3279,3421,0),new Position(3276,3424,0),new Position(3276,3424,0),new Position(3272,3426,0),new Position(3268,3426,0),new Position(3264,3426,0),new Position(3260,3427,0),new Position(3256,3428,0),new Position(3252,3428,0),new Position(3248,3428,0),new Position(3244,3428,0),new Position(3240,3428,0),new Position(3236,3428,0),new Position(3232,3428,0),new Position(3228,3428,0),new Position(3224,3428,0),new Position(3220,3428,0),new Position(3216,3424,0),new Position(3216,3424,0),new Position(3212,3423,0),new Position(3208,3421,0),new Position(3204,3420,0),new Position(3200,3418,0),new Position(3200,3418,0),new Position(3200,3414,0),new Position(3198,3410,0),new Position(3198,3410,0),new Position(3195,3409,0),new Position(3191,3407,0),new Position(3191,3403,0),new Position(3193,3403,0)});
+
+
+    private final DialogueCompleter romeoDialogueCompleter = new DialogueCompleter(
+            "Romeo",
+            ROMEO_AREA,
             "Perhaps I could help to find her for you?",
             "Yes, ok, I'll let her know.",
             "Ok, thanks."
-    };
+    );
 
-    private static final String[] APOTHECARY_OPTIONS = {
+    private final DialogueCompleter apothecaryDialogueCompleter = new DialogueCompleter(
+            "Apothecary",
+            APOTHECARY_AREA,
+            APOTHECARY_PATH,
             "Talk about something else.",
             "Talk about Romeo & Juliet.",
             "Ok, thanks.﻿﻿﻿"
-    };
+    );
+
+    private final DialogueCompleter lawrenceDialogueCompleter = new DialogueCompleter(
+            "Father Lawrence",
+            LAWRENCE_AREA
+    );
+
+    private final DialogueCompleter julietDialogueCompleter = new DialogueCompleter(
+            "Juliet",
+            JULIET_AREA
+    );
 
     private static final String[] QUEST_ITEMS = {
             "Cadava potion",
             "Cadava berries",
             "Message"
     };
+
+    private final ItemCompleter berryItemCompleter = new ItemCompleter(
+            "Cadava bush",
+            "Cadava berries",
+            "Pick-from",
+            BERRIES_AREA,
+            BERRIES_PATH,
+            ItemCompleter.ObjectSelector.RANDOM
+    );
 
     private final DepositAllBanking depositAllBanking = new DepositAllBanking(QUEST_ITEMS);
 
@@ -45,6 +74,11 @@ public class RomeoAndJuliet extends QuestActivity {
     @Override
     public void onStart() {
         depositAllBanking.exchangeContext(getBot());
+        romeoDialogueCompleter.exchangeContext(getBot());
+        apothecaryDialogueCompleter.exchangeContext(getBot());
+        lawrenceDialogueCompleter.exchangeContext(getBot());
+        julietDialogueCompleter.exchangeContext(getBot());
+        berryItemCompleter.exchangeContext(getBot());
     }
 
     @Override
@@ -58,22 +92,22 @@ public class RomeoAndJuliet extends QuestActivity {
             getTabs().open(Tab.INVENTORY);
             return;
         }
-
-        switch (getProgress()) {
+        int progress = getProgress();
+        switch (progress) {
             case 0:
-                talkToRomeo();
+                romeoDialogueCompleter.run();
                 break;
             case 10:
-                talkToJuliet();
+                julietDialogueCompleter.run();
                 break;
             case 20:
-                talkToRomeo();
+                romeoDialogueCompleter.run();
                 break;
             case 30:
-                talkToLawrence();
+                lawrenceDialogueCompleter.run();
                 break;
             case 40:
-                talkToApothecary();
+                apothecaryDialogueCompleter.run(DialogueCompleter.WalkType.WEBWALK);
                 break;
             case 50:
                 // Make sure we are not in the cut scene
@@ -82,7 +116,13 @@ public class RomeoAndJuliet extends QuestActivity {
                         getDialogues().clickContinue();
                     }
                 } else {
-                    deliverCadavaPotion();
+                    if (getInventory().contains("Cadava potion")) {
+                        julietDialogueCompleter.run();
+                    } else if (getInventory().contains("Cadava berries")) {
+                        apothecaryDialogueCompleter.run();
+                    } else {
+                        berryItemCompleter.run();
+                    }
                 }
                 break;
             case 60:
@@ -92,7 +132,7 @@ public class RomeoAndJuliet extends QuestActivity {
                         getDialogues().clickContinue();
                     }
                 } else {
-                    talkToRomeo();
+                    romeoDialogueCompleter.run();
                 }
                 break;
             case 100:
@@ -100,85 +140,9 @@ public class RomeoAndJuliet extends QuestActivity {
                     getDialogues().clickContinue();
                 }
                 break;
-
-        }
-    }
-
-    private void deliverCadavaPotion() throws InterruptedException {
-        if (getInventory().contains("Cadava potion")) {
-            talkToJuliet();
-        } else if (getInventory().contains("Cadava berries")) {
-            talkToApothecary();
-        } else {
-            getItemFromRandomObject(BERRIES, "Cadava berries", "Cadava bush", "Pick-from");
-        }
-    }
-
-    private void talkToApothecary() throws InterruptedException {
-        NPC ApothecaryNPC = getNpcs().closest("Apothecary");
-        if (ApothecaryNPC == null) {
-            getWalking().webWalk(APOTHECARY);
-        } else {
-            completeDialog("Apothecary", APOTHECARY_OPTIONS);
-        }
-
-    }
-
-    private void talkToLawrence() throws InterruptedException {
-        NPC LawrenceNPC = getNpcs().closest("Father Lawrence");
-        if (LawrenceNPC == null) {
-            getWalking().webWalk(LAWRENCE);
-        } else {
-            completeDialog("Father Lawrence");
-        }
-    }
-
-    private void talkToRomeo() throws InterruptedException {
-        NPC RomeoNPC = getNpcs().closest("Romeo");
-        if (RomeoNPC == null) {
-            getWalking().webWalk(ROMEO);
-        } else {
-            completeDialog("Romeo", ROMEO_OPTIONS);
-        }
-    }
-
-    private void talkToJuliet() throws InterruptedException {
-        NPC JulietNPC = getNpcs().closest("Juliet");
-        if (JulietNPC == null) {
-            getWalking().webWalk(JULIET);
-        } else {
-            completeDialog("Juliet");
-        }
-    }
-
-    private void getItemFromRandomObject(Area place, String itemName, String objectName, String interaction) throws InterruptedException {
-        if (place.contains(myPlayer())) {
-            List<RS2Object> objects = getObjects().filter(o -> o.getName().equals(objectName) && o.hasAction(interaction));
-            if(objects.isEmpty()){
-                return;
-            }
-            RS2Object object = objects.get(random(0,objects.size()-1));
-            if (object != null && object.interact(interaction)) {
-                Sleep.sleepUntil(() -> getInventory().contains(itemName), 15000);
-            }
-        } else {
-            getWalking().webWalk(place);
-        }
-
-    }
-
-    private void completeDialog(String npcName, String... options) throws InterruptedException {
-        if (!getDialogues().inDialogue()) {
-            talkTo(npcName);
-        } else {
-            getDialogues().completeDialogue(options);
-        }
-    }
-
-    private void talkTo(String npcName) {
-        NPC npc = getNpcs().closest(npcName);
-        if (npc != null && npc.interact("Talk-to")) {
-            Sleep.sleepUntil(() -> getDialogues().inDialogue(), 5000);
+            default:
+                log("Unknown Romeo&Juliet Quest state ["+progress+"]");
+                break;
         }
     }
 

--- a/AIO/src/org/aio/activities/quests/SheepShearer.java
+++ b/AIO/src/org/aio/activities/quests/SheepShearer.java
@@ -38,14 +38,6 @@ public class SheepShearer extends QuestActivity {
             "I'm something of an expert actually!"
     );
 
-    private final DialogueCompleter farmerBackDialogueCompleter = new DialogueCompleter(
-            "Fred the Farmer",
-            FARMER_AREA,
-            "I'm looking for a quest.",
-            "Yes okay. I can do that.",
-            "Of course!",
-            "I'm something of an expert actually!"
-    );
     private final ItemCompleter shearsItemCompleter = new ItemCompleter("Shears", FARMER_AREA);
 
     private final ItemCompleter woolItemCompleter = new ItemCompleter(

--- a/AIO/src/org/aio/activities/quests/SheepShearer.java
+++ b/AIO/src/org/aio/activities/quests/SheepShearer.java
@@ -37,7 +37,23 @@ public class SheepShearer extends QuestActivity {
             "Of course!",
             "I'm something of an expert actually!"
     );
+
+    private final DialogueCompleter farmerBackDialogueCompleter = new DialogueCompleter(
+            "Fred the Farmer",
+            FARMER_AREA,
+            "I'm looking for a quest.",
+            "Yes okay. I can do that.",
+            "Of course!",
+            "I'm something of an expert actually!"
+    );
     private final ItemCompleter shearsItemCompleter = new ItemCompleter("Shears", FARMER_AREA);
+
+    private final ItemCompleter woolItemCompleter = new ItemCompleter(
+            "Sheep",
+            "Wool",
+            "Shear",
+            SHEEP_AREA
+    );
 
 
     private final DepositAllBanking depositAllBanking = new DepositAllBanking(ITEMS_NEEDED);
@@ -51,6 +67,7 @@ public class SheepShearer extends QuestActivity {
         depositAllBanking.exchangeContext(getBot());
         farmerDialogueCompleter.exchangeContext(getBot());
         shearsItemCompleter.exchangeContext(getBot());
+        woolItemCompleter.exchangeContext(getBot());
         makeAllInterface = new MakeAllInterface("Ball of Wool");
         makeAllInterface.exchangeContext(getBot());
     }
@@ -70,6 +87,7 @@ public class SheepShearer extends QuestActivity {
                     if (hasRequiredItems()) {
                         farmerDialogueCompleter.run();
                     } else {
+                        log("fuck");
                         getItemsNeeded();
                     }
                     break;
@@ -93,21 +111,9 @@ public class SheepShearer extends QuestActivity {
         if (!getInventory().contains("Shears")) {
             shearsItemCompleter.run();
         } else if (!getInventory().contains("Ball of wool") && getInventory().getAmount("Wool") < 20) {
-            getItemFromNPC(SHEEP_AREA, "Shear");
+            woolItemCompleter.run();
         } else if (getInventory().getAmount("Ball of wool") < 20) {
             useObject(SPINNER_AREA, "Spin");
-        }
-    }
-
-    private void getItemFromNPC(Area place, String interaction) throws InterruptedException {
-        if (place.contains(myPlayer())) {
-            NPC npc = getNpcs().closest(n -> !n.hasAction("Talk-to") && n.hasAction(interaction) && place.contains(n));
-            if (npc != null && npc.interact(interaction)) {
-                Sleep.sleepUntil(() -> myPlayer().getAnimation() == 893, 15000);
-                Sleep.sleepUntil(() -> !myPlayer().isAnimating(), 10000);
-            }
-        } else {
-            getWalking().webWalk(place);
         }
     }
 

--- a/AIO/src/org/aio/activities/skills/fishing/FishingActivity.java
+++ b/AIO/src/org/aio/activities/skills/fishing/FishingActivity.java
@@ -69,34 +69,9 @@ public class FishingActivity extends Activity {
         } else if (getInventory().isFull() && resourceMode == ResourceMode.DROP) {
             getInventory().dropAll(item -> item.getName().startsWith("Raw "));
         } else if (!location.location.getArea().contains(myPosition())) {
-            if (location == FishingLocation.MUSA_POINT) {
-                walkToMusaPoint();
-            } else {
-                getWalking().webWalk(location.location.getArea());
-            }
+            getWalking().webWalk(location.location.getArea());
         } else if (!myPlayer().isInteracting(currentFishingSpot) || getDialogues().isPendingContinuation()){
             fish();
-        }
-    }
-
-    private void walkToMusaPoint() throws InterruptedException {
-        Optional<RS2Widget> charterWidget = musaPointCharterWidget.get(getWidgets()).filter(RS2Widget::isVisible);
-
-        if (getDialogues().isPendingContinuation()) {
-            getDialogues().clickContinue();
-        } else if (charterWidget.isPresent()) {
-            if (charterWidget.get().interact()) {
-                sleep(2000);
-            }
-        } else {
-            WebWalkEvent webWalkEvent = new WebWalkEvent(FishingLocation.MUSA_POINT.location.getArea());
-            webWalkEvent.setBreakCondition(new Condition() {
-                @Override
-                public boolean evaluate() {
-                    return musaPointCharterWidget.get(getWidgets()).filter(RS2Widget::isVisible).isPresent();
-                }
-            });
-            execute(webWalkEvent);
         }
     }
 


### PR DESCRIPTION
# Changes DialogCompleter
Refactored DialogCompleter => Constructor
Added Path Support for DialogCompleter (For more supported situations, example: Romeo and Juliet)
Added ForcedWalkType for DialogCompleter (not really happy with this solution)

# Implemented DialogCompleter
 On Romeo & Juliet
 On Cooks Assistant
 On Sheep Shearer

# New ItemCompleter
Same as DialogCompleter => I saw alot of different implementations of GetItemFromGround or GetItemFromObject. Now all in one class.
Supports ground items / items from objects and items from simple npcs (without dialog)

# Implemented ItemCompleter
 On Romeo & Juliet
 On Cooks Assistant
 On Sheep Shearer

# Fix on Romeo & Juliet

#39 is implement now with the new DialogCompleter