### PR TITLE
Fixed smithing item withdraw bar instead of ore

### DIFF
--- a/AIO/src/org/aio/activities/skills/smithing/item_making/SmithItemMakingActivity.java
+++ b/AIO/src/org/aio/activities/skills/smithing/item_making/SmithItemMakingActivity.java
@@ -32,7 +32,7 @@ public class SmithItemMakingActivity extends Activity {
         smithItemWidget = new CachedWidget(smithItem.name);
 
         List<ItemReq> itemReqs = new ArrayList<>();
-        Collections.addAll(itemReqs, bar.oresRequired);
+        itemReqs.add(new ItemReq(bar.toString(), smithItem.barsRequired));
         itemReqs.add(new ItemReq("Hammer"));
         this.itemReqs = itemReqs.toArray(new ItemReq[0]);
     }


### PR DESCRIPTION
The script would withdraw ores instead of bars when trying to smith items.