### PR TITLE
Update Axe.java

### DIFF
--- a/src/main/java/activities/skills/woodcutting/Axe.java
+++ b/src/main/java/activities/skills/woodcutting/Axe.java
@@ -9,7 +9,7 @@ public enum Axe implements Tool {
     BRONZE("Bronze axe", 1, 1),
     IRON("Iron axe", 1, 1),
     STEEL("Steel axe", 6, 5),
-    BLACK("Black axe", 6, 10),
+    BLACK("Black axe", 11, 10),
     MITHRIL("Mithril axe", 21, 20),
     ADAMANT("Adamant axe", 31, 30),
     RUNE("Rune axe", 41, 40),


### PR DESCRIPTION
Black axe woodcutting requirement is level 11 not 6

![Axes](https://user-images.githubusercontent.com/50358926/57319689-c12f1280-712f-11e9-8e5e-206a35917316.PNG)
